### PR TITLE
Update index.js to pin older version of datadog image

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -113,7 +113,7 @@ class ServerlessFargateTasks {
         } else {
           var datadog_agent_definition = {
             'Name': `${this.service.service}-${this.stage}-datadog-agent`,
-            'Image': "public.ecr.aws/datadog/agent:latest",
+            'Image': "public.ecr.aws/datadog/agent:7.50.3",
             'Essential': options.datadog.essential || false,
             'Cpu': options.datadog.cpu || 10,
             'MemoryReservation': options.datadog.memory || 256,

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,7 +113,7 @@ class ServerlessFargateTasks {
         } else {
           var datadog_agent_definition = {
             'Name': `${this.service.service}-${this.stage}-datadog-agent`,
-            'Image': "public.ecr.aws/datadog/agent:7.50.3",
+            'Image': `public.ecr.aws/datadog/agent:${options.datadog.image_tag || "latest"}`,
             'Essential': options.datadog.essential || false,
             'Cpu': options.datadog.cpu || 10,
             'MemoryReservation': options.datadog.memory || 256,


### PR DESCRIPTION
Data engineering team has been witnessing random failures without any backend failures causing confusion and false alarms. A latest Datadog version seems to be causing the issue. We need this change to use a previous version of datadog image to try and see if the false alerts cease.