### PR TITLE
Switch to use private ECR for datadog agent to reduce traffic from public.ecr 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ custom:
     
     datadog:
       ssm_api_key: /datadog/api_key  # Replace with the name of your SSM parameter (if in same account as the task), or full ARN
+      image_account_id: ${aws:accountId} # Required
       essential: true  # Optional, marks container as essential. Default is false.
       cpu: 10  # Optional, sets the CPU units for the individual container. Defaults to DataDog recommended 10 units.
       memory: 256  # Optional, sets the soft memory limit for the individual container. Defaults to DataDog recommended 256. 

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,10 +110,12 @@ class ServerlessFargateTasks {
       if (options.datadog) {
         if (!options.datadog.ssm_api_key) {
           throw new Error(`Required property 'ssm_api_key' missing from 'custom.fargate.datadog'`);
+        } else if (!options.datadog.image_account_id) {
+          throw new Error(`Required property 'image_account_id' missing from 'custom.fargate.datadog'`);
         } else {
           var datadog_agent_definition = {
             'Name': `${this.service.service}-${this.stage}-datadog-agent`,
-            'Image': `public.ecr.aws/datadog/agent:${options.datadog.image_tag || "latest"}`,
+            'Image':  `${options.datadog.image_account_id}.dkr.ecr.us-east-1.amazonaws.com/ecr-public/datadog/agent:${options.datadog.image_tag || "latest"}`,
             'Essential': options.datadog.essential || false,
             'Cpu': options.datadog.cpu || 10,
             'MemoryReservation': options.datadog.memory || 256,
@@ -162,6 +164,10 @@ class ServerlessFargateTasks {
         }
       });
     }
+  }
+
+  getAccountId() {
+    return this.provider.request("STS", "getCallerIdentity", {}, { useCache: true });
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -165,10 +165,6 @@ class ServerlessFargateTasks {
       });
     }
   }
-
-  getAccountId() {
-    return this.provider.request("STS", "getCallerIdentity", {}, { useCache: true });
-  }
 }
 
 function get(obj, path, def) {

--- a/package.json
+++ b/package.json
@@ -13,5 +13,5 @@
     "url": "git+https://github.com/MarletteFunding/serverless-fargate-tasks.git"
   },
   "scripts": {},
-  "version": "0.5.2"
+  "version": "0.5.4"
 }


### PR DESCRIPTION
Requires a change to all repos that use the plugin: 
```yaml
custom:
  fargate:
    datadog:
      ssm_api_key: /Keys/Datadog/ApiKey
+     image_account_id: ${aws:accountId}
      image_tag: 7.50.3
```